### PR TITLE
Fix query argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 ---
 An Atom package that provides grammar and snippets of TeX and its related stuff.
 
-![sample of language-tex package](http://github.com/yudai-nkt/language-tex/blob/master/_img/preview.png?raw=true "sample of language-tex package")
+![sample of language-tex package](https://raw.githubusercontent.com/yudai-nkt/language-tex/master/_img/preview.png "sample of language-tex package")
 
 ### Overview
 The `language-tex` package provides your Atom with grammar and code snippets of TeX, LaTeX, BibTeX and so on.


### PR DESCRIPTION
The previous fix worked on atom.io but it looks like it broke README.md on GitHub. Looks like GitHub doesn't like the either `?raw=true` or the redirect URI part so I switched to the resolved url. Sorry for the confusion.
