### PR TITLE
Add figure and table environments

### DIFF
--- a/snippets/language-latex.cson
+++ b/snippets/language-latex.cson
@@ -49,6 +49,9 @@
   'equation(*)':
     'prefix': 'equation'
     'body': '\\\\begin{equation$1}\n\t$0\n\\\\end{equation$1}'
+  'figure':
+    'prefix': 'figure'
+    'body': '\\\\begin{figure}\n\t\\\\includegraphics{$2}\n\t\\\\caption{$1}\n\\\\end{figure}'
   'gather(*)':
       'prefix': 'gather'
       'body': '\\\\begin{gather$1}\n\t$0\n\\\\end{gather$1}'
@@ -58,6 +61,9 @@
   'itemize':
     'prefix': 'itemize'
     'body': '\\\\begin{itemize}\n\t\\\\item $0\n\\\\end{itemize}'
+  'table':
+    'prefix': 'table'
+    'body': '\\\\begin{table}\n\t\\\\caption{$1}\n\t\$2\n\\\\end{table}'
 
 # element
   'inline math - $$':


### PR DESCRIPTION
A little change. I'm a lazy person so this goes for all other lazy people. If equation has a snippet, then the figure and table environments should have one too?
