### PR TITLE
Improve TeX magic pattern

### DIFF
--- a/grammars/tex.cson
+++ b/grammars/tex.cson
@@ -47,7 +47,7 @@
         'name': 'comment.line.percentage.semicolon.texshop.tex'
       }
       {
-        'begin': '^(%!TEX) (\\S*) ='
+        'begin': '^(%\\s*!T[eE]X)\\s+(\\w+)\\s*='
         'beginCaptures':
           '1':
             'name': 'punctuation.definition.comment.tex'


### PR DESCRIPTION
This PR makes the TeX magic pattern more flexible. It appears that magic comments have some variation in usage and are not guaranteed to be all uppercase and not have spaces between `%` and `!`. For example, `% !TeX foo = xyz` is also used.  [TeXworks ‘magic comments’](http://www.texdev.net/2011/03/24/texworks-magic-comments/) has some further examples.
